### PR TITLE
Add Jest testing setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,16 @@
   "description": "",
   "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "start": "node server.js"
   },
   "author": "",
   "license": "ISC",
   "dependencies": {
     "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "jest": "^29.6.1",
+    "supertest": "^6.3.3"
   }
 }

--- a/server.js
+++ b/server.js
@@ -47,6 +47,10 @@ app.get('/lastClickedTimes', (req, res) => {
     res.send(lastClickedTimes);
 });
 
-app.listen(port, '0.0.0.0', () => {
-    console.log(`Server listening at http://localhost:${port}`);
-});
+if (require.main === module) {
+    app.listen(port, '0.0.0.0', () => {
+        console.log(`Server listening at http://localhost:${port}`);
+    });
+}
+
+module.exports = app;

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,0 +1,19 @@
+const request = require('supertest');
+const app = require('../server');
+
+describe('Server endpoints', () => {
+  test('GET /lastClickedTimes returns status 200 and JSON', async () => {
+    const res = await request(app).get('/lastClickedTimes');
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toMatch(/json/);
+    expect(typeof res.body).toBe('object');
+  });
+
+  test('POST /clicked responds with updated timestamp', async () => {
+    const res = await request(app)
+      .post('/clicked')
+      .send({ buttonId: 'sample-button' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveProperty('lastClickedTime');
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest and Supertest dev dependencies
- export Express app to allow testing
- create basic integration tests
- update npm test script

## Testing
- `npm test` *(fails: jest not found)*