### PR TITLE
Fix archiving bug

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -95,7 +95,9 @@ document.addEventListener('DOMContentLoaded', () => {
         const response = await fetch('/lastClickedTimes');
         const data = await response.json();
         Object.entries(data).forEach(([buttonId, time]) => {
-            updateButtonState(buttonId, time);
+            if (buttonRefs[buttonId]) {
+                updateButtonState(buttonId, time);
+            }
         });
     };
 

--- a/server.js
+++ b/server.js
@@ -89,6 +89,16 @@ app.put('/plants/:name', (req, res) => {
         return res.status(404).send('Plant not found');
     }
     plants[index] = { ...plants[index], ...req.body };
+
+    if (req.body.archived === true) {
+        Object.keys(lastClickedTimes).forEach(key => {
+            if (key.startsWith(`button-${req.params.name}-`)) {
+                delete lastClickedTimes[key];
+            }
+        });
+        writeLastClickedTimes();
+    }
+
     writePlants();
     res.send(plants[index]);
 });
@@ -119,6 +129,14 @@ app.delete('/plants/:name', (req, res) => {
         return res.status(404).send('Plant not found');
     }
     const removed = plants.splice(index, 1)[0];
+
+    Object.keys(lastClickedTimes).forEach(key => {
+        if (key.startsWith(`button-${req.params.name}-`)) {
+            delete lastClickedTimes[key];
+        }
+    });
+    writeLastClickedTimes();
+
     writePlants();
     res.send(removed);
 });

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -48,6 +48,28 @@ describe('Server endpoints', () => {
       .send({ archived: false });
   });
 
+  test('Archiving a plant removes its lastClickedTimes entries', async () => {
+    const name = 'Fougère';
+
+    await request(app).post('/clicked').send({ buttonId: `button-${name}-Arrosage` });
+    await request(app).post('/clicked').send({ buttonId: `button-${name}-Engrais` });
+
+    const archiveRes = await request(app)
+      .put('/plants/' + encodeURIComponent(name))
+      .send({ archived: true });
+    expect(archiveRes.statusCode).toBe(200);
+
+    const times = await request(app).get('/lastClickedTimes');
+    const hasEntry = Object.keys(times.body).some(k => k.includes(name));
+    expect(hasEntry).toBe(false);
+
+    await request(app)
+      .put('/plants/' + encodeURIComponent(name))
+      .send({ archived: false });
+    await request(app).post('/clicked').send({ buttonId: `button-${name}-Arrosage` });
+    await request(app).post('/clicked').send({ buttonId: `button-${name}-Engrais` });
+  });
+
   test('POST /plants creates and DELETE removes a plant', async () => {
     const newPlant = {
       name: 'TestPlant',


### PR DESCRIPTION
## Summary
- remove lastClickedTimes entries when a plant gets archived or deleted
- ignore unknown buttons when refreshing last clicked times
- add regression test for archiving last clicked times

## Testing
- `npm test --silent`