### PR TITLE
Improve monthly frequency input UI

### DIFF
--- a/public/create.html
+++ b/public/create.html
@@ -18,12 +18,12 @@
         <textarea id="description" rows="4" class="form-control"></textarea>
     </div>
     <div class="mb-3">
-        <label class="form-label">Watering frequency (12 numbers, comma separated)</label>
-        <input type="text" id="watering" class="form-control" />
+        <label class="form-label">Watering frequency by month (days between watering)</label>
+        <div id="watering-inputs" class="d-flex flex-nowrap gap-1"></div>
     </div>
     <div class="mb-3">
-        <label class="form-label">Feeding frequency (12 numbers, comma separated)</label>
-        <input type="text" id="feeding" class="form-control" />
+        <label class="form-label">Feeding frequency by month (days between feeding)</label>
+        <div id="feeding-inputs" class="d-flex flex-nowrap gap-1"></div>
     </div>
     <div class="mb-3">
         <label class="form-label">Image path</label>

--- a/public/create.js
+++ b/public/create.js
@@ -1,8 +1,31 @@
 document.addEventListener('DOMContentLoaded', () => {
     const nameElem = document.getElementById('name');
     const descElem = document.getElementById('description');
-    const wateringElem = document.getElementById('watering');
-    const feedingElem = document.getElementById('feeding');
+    const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+    const createMonthInputs = (containerId, prefix, defaultValue) => {
+        const container = document.getElementById(containerId);
+        const inputs = [];
+        months.forEach((m, i) => {
+            const div = document.createElement('div');
+            div.className = 'month-container';
+            const label = document.createElement('label');
+            label.className = 'form-label mb-1';
+            label.textContent = m;
+            const input = document.createElement('input');
+            input.type = 'number';
+            input.className = 'form-control form-control-sm month-input';
+            input.id = `${prefix}-${i}`;
+            input.value = defaultValue;
+            div.appendChild(label);
+            div.appendChild(input);
+            container.appendChild(div);
+            inputs.push(input);
+        });
+        return inputs;
+    };
+
+    const wateringInputs = createMonthInputs('watering-inputs', 'watering', 7);
+    const feedingInputs = createMonthInputs('feeding-inputs', 'feeding', 30);
     const imageElem = document.getElementById('image');
     const saveBtn = document.getElementById('save');
     const messageElem = document.getElementById('message');
@@ -18,8 +41,8 @@ document.addEventListener('DOMContentLoaded', () => {
         const body = {
             name: nameElem.value.trim(),
             description: descElem.value,
-            wateringFreq: wateringElem.value.split(',').map(n => parseInt(n.trim(), 10)),
-            feedingFreq: feedingElem.value.split(',').map(n => parseInt(n.trim(), 10)),
+            wateringFreq: wateringInputs.map(input => parseInt(input.value, 10) || 0),
+            feedingFreq: feedingInputs.map(input => parseInt(input.value, 10) || 0),
             image: imageElem.value
         };
         const res = await fetch('/plants', {

--- a/public/plant.html
+++ b/public/plant.html
@@ -15,12 +15,12 @@
         <textarea id="description" rows="4" class="form-control"></textarea>
     </div>
     <div class="mb-3">
-        <label class="form-label">Watering frequency (12 numbers, comma separated)</label>
-        <input type="text" id="watering" class="form-control" />
+        <label class="form-label">Watering frequency by month (days between watering)</label>
+        <div id="watering-inputs" class="d-flex flex-nowrap gap-1"></div>
     </div>
     <div class="mb-3">
-        <label class="form-label">Feeding frequency (12 numbers, comma separated)</label>
-        <input type="text" id="feeding" class="form-control" />
+        <label class="form-label">Feeding frequency by month (days between feeding)</label>
+        <div id="feeding-inputs" class="d-flex flex-nowrap gap-1"></div>
     </div>
     <button id="save" class="btn btn-primary me-2">Save</button>
     <button id="archive" class="btn btn-secondary">Archive</button>

--- a/public/plant.js
+++ b/public/plant.js
@@ -6,8 +6,31 @@ document.addEventListener('DOMContentLoaded', () => {
     const plantNameElem = document.getElementById('plant-name');
     const imageElem = document.getElementById('plant-image');
     const descElem = document.getElementById('description');
-    const wateringElem = document.getElementById('watering');
-    const feedingElem = document.getElementById('feeding');
+    const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+    const createMonthInputs = (containerId, prefix, defaultValue) => {
+        const container = document.getElementById(containerId);
+        const inputs = [];
+        months.forEach((m, i) => {
+            const div = document.createElement('div');
+            div.className = 'month-container';
+            const label = document.createElement('label');
+            label.className = 'form-label mb-1';
+            label.textContent = m;
+            const input = document.createElement('input');
+            input.type = 'number';
+            input.className = 'form-control form-control-sm month-input';
+            input.id = `${prefix}-${i}`;
+            input.value = defaultValue;
+            div.appendChild(label);
+            div.appendChild(input);
+            container.appendChild(div);
+            inputs.push(input);
+        });
+        return inputs;
+    };
+
+    const wateringInputs = createMonthInputs('watering-inputs', 'watering', 7);
+    const feedingInputs = createMonthInputs('feeding-inputs', 'feeding', 30);
     const saveBtn = document.getElementById('save');
     const archiveBtn = document.getElementById('archive');
     const messageElem = document.getElementById('message');
@@ -26,8 +49,12 @@ document.addEventListener('DOMContentLoaded', () => {
             plantNameElem.textContent = plant.name;
             imageElem.src = plant.image;
             descElem.value = plant.description || '';
-            wateringElem.value = (plant.wateringFreq || []).join(',');
-            feedingElem.value = (plant.feedingFreq || []).join(',');
+            (plant.wateringFreq || []).forEach((val, i) => {
+                if (wateringInputs[i]) wateringInputs[i].value = val;
+            });
+            (plant.feedingFreq || []).forEach((val, i) => {
+                if (feedingInputs[i]) feedingInputs[i].value = val;
+            });
             archiveBtn.disabled = !!plant.archived;
         }
     };
@@ -35,8 +62,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const save = async () => {
         const body = {
             description: descElem.value,
-            wateringFreq: wateringElem.value.split(',').map(n => parseInt(n.trim(), 10)),
-            feedingFreq: feedingElem.value.split(',').map(n => parseInt(n.trim(), 10))
+            wateringFreq: wateringInputs.map(input => parseInt(input.value, 10) || 0),
+            feedingFreq: feedingInputs.map(input => parseInt(input.value, 10) || 0)
         };
         await fetch(`/plants/${encodeURIComponent(name)}`, {
             method: 'PUT',

--- a/public/styles.css
+++ b/public/styles.css
@@ -50,3 +50,21 @@ img {
 #create-plant {
     margin-top: 20px;
 }
+
+/* Compact monthly frequency inputs */
+.month-container {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.month-container label {
+    font-size: 0.75rem;
+    margin-bottom: 2px;
+}
+
+.month-input {
+    width: 50px;
+    padding: 2px 4px;
+    text-align: center;
+}


### PR DESCRIPTION
## Summary
- show watering and feeding frequencies per month on plant & create pages
- render month input grid in plant.js and create.js
- add default values and compact layout for month inputs

## Testing
- `npm test`
