### PR TITLE
Allow uploading new plant pictures

### DIFF
--- a/public/create.html
+++ b/public/create.html
@@ -29,6 +29,10 @@
         <label class="form-label">Image path</label>
         <input type="text" id="image" class="form-control" value="images/placeholder.jpg" />
     </div>
+    <div class="mb-3">
+        <label class="form-label">Upload image</label>
+        <input type="file" id="imageFile" class="form-control" accept="image/*" capture="environment" />
+    </div>
     <button id="save" class="btn btn-primary">Save</button>
     <script src="create.js"></script>
 </body>

--- a/public/create.js
+++ b/public/create.js
@@ -27,8 +27,20 @@ document.addEventListener('DOMContentLoaded', () => {
     const wateringInputs = createMonthInputs('watering-inputs', 'watering', 7);
     const feedingInputs = createMonthInputs('feeding-inputs', 'feeding', 30);
     const imageElem = document.getElementById('image');
+    const imageFileElem = document.getElementById('imageFile');
     const saveBtn = document.getElementById('save');
     const messageElem = document.getElementById('message');
+    let imageData = null;
+
+    if (imageFileElem) {
+        imageFileElem.addEventListener('change', () => {
+            const file = imageFileElem.files[0];
+            if (!file) { imageData = null; return; }
+            const reader = new FileReader();
+            reader.onload = () => { imageData = reader.result; };
+            reader.readAsDataURL(file);
+        });
+    }
 
     const showMessage = (msg, type = 'success') => {
         messageElem.textContent = msg;
@@ -42,9 +54,13 @@ document.addEventListener('DOMContentLoaded', () => {
             name: nameElem.value.trim(),
             description: descElem.value,
             wateringFreq: wateringInputs.map(input => parseInt(input.value, 10) || 0),
-            feedingFreq: feedingInputs.map(input => parseInt(input.value, 10) || 0),
-            image: imageElem.value
+            feedingFreq: feedingInputs.map(input => parseInt(input.value, 10) || 0)
         };
+        if (imageData) {
+            body.imageData = imageData;
+        } else {
+            body.image = imageElem.value;
+        }
         const res = await fetch('/plants', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },

--- a/public/plant.html
+++ b/public/plant.html
@@ -11,6 +11,10 @@
     <div id="message" class="alert d-none" role="alert"></div>
     <img id="plant-image" src="" alt="Plant image" class="mb-3" />
     <div class="mb-3">
+        <label class="form-label">Change image</label>
+        <input type="file" id="imageFile" class="form-control" accept="image/*" capture="environment" />
+    </div>
+    <div class="mb-3">
         <label class="form-label">Description</label>
         <textarea id="description" rows="4" class="form-control"></textarea>
     </div>

--- a/public/plant.js
+++ b/public/plant.js
@@ -5,7 +5,22 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const plantNameElem = document.getElementById('plant-name');
     const imageElem = document.getElementById('plant-image');
+    const imageFileElem = document.getElementById('imageFile');
     const descElem = document.getElementById('description');
+    let imageData = null;
+
+    if (imageFileElem) {
+        imageFileElem.addEventListener('change', () => {
+            const file = imageFileElem.files[0];
+            if (!file) { imageData = null; return; }
+            const reader = new FileReader();
+            reader.onload = () => {
+                imageData = reader.result;
+                imageElem.src = imageData;
+            };
+            reader.readAsDataURL(file);
+        });
+    }
     const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
     const createMonthInputs = (containerId, prefix, defaultValue) => {
         const container = document.getElementById(containerId);
@@ -65,6 +80,9 @@ document.addEventListener('DOMContentLoaded', () => {
             wateringFreq: wateringInputs.map(input => parseInt(input.value, 10) || 0),
             feedingFreq: feedingInputs.map(input => parseInt(input.value, 10) || 0)
         };
+        if (imageData) {
+            body.imageData = imageData;
+        }
         await fetch(`/plants/${encodeURIComponent(name)}`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },

--- a/server.js
+++ b/server.js
@@ -37,6 +37,20 @@ function writePlants() {
         }
     });
 }
+// Save base64 image data to disk and return relative path
+function saveBase64Image(data) {
+    const match = /^data:(image\/\w+);base64,(.+)$/.exec(data || '');
+    if (!match) return null;
+    const ext = match[1].split('/')[1];
+    const fileName = `img_${Date.now()}.${ext}`;
+    try {
+        fs.writeFileSync(`public/images/${fileName}`, match[2], 'base64');
+        return `images/${fileName}`;
+    } catch (err) {
+        console.error('Failed to save image', err);
+        return null;
+    }
+}
 // Function to write the last clicked times to a file
 function writeLastClickedTimes() {
     fs.writeFile(dataFile, JSON.stringify(lastClickedTimes, null, 4), err => {
@@ -108,6 +122,13 @@ app.put('/plants/:name', (req, res) => {
     if (index === -1) {
         return res.status(404).send('Plant not found');
     }
+    if (req.body.imageData) {
+        const saved = saveBase64Image(req.body.imageData);
+        if (saved) {
+            req.body.image = saved;
+        }
+        delete req.body.imageData;
+    }
     if (req.body.wateringFreq && !isValidFreqArray(req.body.wateringFreq)) {
         return res.status(400).send('wateringFreq must be an array of 12 numbers');
     }
@@ -136,6 +157,13 @@ app.post('/plants', (req, res) => {
     }
     if (plants.find(p => p.name === newPlant.name)) {
         return res.status(400).send('Plant already exists');
+    }
+    if (newPlant.imageData) {
+        const saved = saveBase64Image(newPlant.imageData);
+        if (saved) {
+            newPlant.image = saved;
+        }
+        delete newPlant.imageData;
     }
     if (newPlant.wateringFreq && !isValidFreqArray(newPlant.wateringFreq)) {
         return res.status(400).send('wateringFreq must be an array of 12 numbers');


### PR DESCRIPTION
## Summary
- add `saveBase64Image` helper to store uploaded image data
- support image uploads during plant creation and update
- allow choosing an image file when creating or editing a plant
- send base64 image data from the frontend

## Testing
- `npm test`