### PR TITLE
Add identify result to plant description

### DIFF
--- a/public/plant.js
+++ b/public/plant.js
@@ -161,6 +161,15 @@ document.addEventListener('DOMContentLoaded', async () => {
         setTimeout(() => { window.location.href = 'index.html'; }, 1000);
     };
 
+    const updateDescription = async (text, showMsg = true) => {
+        await fetch(`/plants/${encodeURIComponent(name)}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ description: text })
+        });
+        if (showMsg) showMessage('Description updated', 'success');
+    };
+
     const archive = async () => {
         await fetch(`/plants/${encodeURIComponent(name)}`, {
             method: 'PUT',
@@ -180,6 +189,9 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (res.ok) {
             const data = await res.json();
             try { await navigator.clipboard.writeText(data.answer); } catch(e) {}
+            descElem.value = data.answer;
+            autoResize();
+            await updateDescription(data.answer, false);
             alert(data.answer);
         } else {
             alert('Error identifying plant');

--- a/server.js
+++ b/server.js
@@ -226,7 +226,10 @@ app.post('/identify', async (req, res) => {
                 messages: [{
                     role: 'user',
                     content: [
-                        { type: 'text', text: 'Quel est cette plante? Donnes moi le nom de l’espèce (scientifique et commun si possible), quelques particularités et des conseils d’entretien (lumière, arrosage, engrais, etc.). Ta réponse doit être concise, sous forme de bullet points et sans ligne vide' },
+                        {
+                            type: 'text',
+                            text: 'Quel est cette plante? Donnes moi le nom de l\u2019esp\u00e8ce (scientifique et commun si possible), quelques particularit\u00e9s et des conseils d\u2019entretien (lumi\u00e8re, arrosage, engrais, etc.). R\u00e9ponds en fran\u00e7ais en 6 lignes maximum, chaque ligne commen\u00e7ant par \u201c- \u201d et sans ligne vide.'
+                        },
                         { type: 'image_url', image_url: { url: `data:image/jpeg;base64,${base64}` } }
                     ]
                 }],


### PR DESCRIPTION
## Summary
- improve OpenAI prompt for concise bullet list
- allow identify button to auto-fill plant description and save it
- avoid duplicate alert when identifying a plant

## Testing
- `npm test`
