### PR TITLE
Fix offline pages by caching offline script

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -12,6 +12,7 @@ const PRECACHE = [
   '/styles.css',
   '/leafAnimations.js',
   '/config.js',
+  '/offline.js',
   '/offlineData.js'
 ];
 


### PR DESCRIPTION
## Summary
- add `offline.js` to the service worker precache so offline pages load cached data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_683a1fc13dd0832a92d02bf1e4270f6a