### PR TITLE
Add offline read-only syncing support

### DIFF
--- a/docs/offline-sync.md
+++ b/docs/offline-sync.md
@@ -1,0 +1,31 @@
+# Offline synchronisation
+
+## IndexedDB schema (via localforage)
+- `plants`: cached array of plant objects (with `id`, `name`, `location`, `updatedAt`, `archived`, `image`).
+- `locations`: cached array of location names.
+- `times`: cached `lastClickedTimes` object.
+- `sync`: stores `{ lastServerRev, lastSyncAt }` metadata.
+- `images`: blobs keyed by `"<plantId>:<updatedAt>"` for offline photos.
+
+## /sync protocol
+- `GET /sync?since=<rev>` returns:
+  - `serverRev`: current server revision integer.
+  - `plants`: `{ upsert: [...], deleted: [{id,name}, ...] }` where `upsert` contains full plant objects.
+  - `locations`: `{ upsert: [...], deleted: [...] }` with location names.
+  - `lastClickedTimes`: present on full sync or when the timestamp revision changed.
+  - `images`: `{ changed: [{ plantId, image, updatedAt }], deleted: [...] }` to allow image cache refresh.
+- When `since` is omitted the response includes a full snapshot.
+
+## Client caching strategy
+- Data access flows through `public/js/dataClient.js` which tries a short-timeout fetch first and falls back to cached data on failure, marking connectivity offline.
+- `syncIfOnline()` calls `/sync` with the last known revision, applies upserts/deletions to the stores, refreshes image blobs, and updates `sync` metadata.
+- `getPlantImage()` returns a blob URL from cache when available, otherwise downloads and caches the current image.
+
+## Offline read-only behaviour
+- Connectivity state is tracked in `public/js/connectivity.js` (navigator `online/offline` events plus failed fetch detection).
+- In offline mode buttons that mutate data are disabled and an “Offline (lecture seule)” banner is shown.
+- Mutating attempts while offline surface an “Indisponible hors-ligne” alert.
+
+## Known limitations
+- Image caching fetches serially on sync; very large libraries may take longer to warm the cache.
+- The server keeps a simple tombstone list for deletions without compaction.

--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,9 @@
     <link href="styles.css" rel="stylesheet">
 </head>
 <body class="container">
+    <div id="offline-indicator" class="alert alert-warning text-center" role="alert" style="display:none;">
+        Offline (lecture seule)
+    </div>
     <div class="d-flex justify-content-end mb-2 align-items-center top-controls">
         <select id="location-select" class="form-select w-auto"></select>
         <a href="locations.html" class="btn btn-outline-secondary ms-2">Manage</a>

--- a/public/js/connectivity.js
+++ b/public/js/connectivity.js
@@ -1,0 +1,23 @@
+const listeners = new Set();
+let state = navigator.onLine ? 'online' : 'offline';
+
+function notify(){
+    listeners.forEach(fn => fn(state));
+}
+
+function setState(newState){
+    if (state === newState) return;
+    state = newState;
+    notify();
+}
+
+export const connectivity = {
+    isOffline: () => state === 'offline',
+    mode: () => state,
+    setOffline: () => setState('offline'),
+    setOnline: () => setState('online'),
+    onChange: (fn) => { listeners.add(fn); return () => listeners.delete(fn); }
+};
+
+window.addEventListener('online', () => setState('online'));
+window.addEventListener('offline', () => setState('offline'));

--- a/public/js/connectivity.js
+++ b/public/js/connectivity.js
@@ -1,5 +1,12 @@
 const listeners = new Set();
-let state = navigator.onLine ? 'online' : 'offline';
+let state = 'unknown';
+
+function withBase(path){
+    if (window.API_BASE){
+        return window.API_BASE.replace(/\/$/, '') + path;
+    }
+    return path;
+}
 
 function notify(){
     listeners.forEach(fn => fn(state));
@@ -11,13 +18,31 @@ function setState(newState){
     notify();
 }
 
+async function pingServer(timeout = 2000){
+    const controller = new AbortController();
+    const id = setTimeout(() => controller.abort(), timeout);
+    try {
+        const res = await fetch(withBase('/ping'), { method: 'GET', cache: 'no-store', signal: controller.signal });
+        clearTimeout(id);
+        setState(res.ok ? 'online' : 'offline');
+    } catch (err){
+        clearTimeout(id);
+        setState('offline');
+    }
+    return state;
+}
+
 export const connectivity = {
     isOffline: () => state === 'offline',
     mode: () => state,
     setOffline: () => setState('offline'),
     setOnline: () => setState('online'),
-    onChange: (fn) => { listeners.add(fn); return () => listeners.delete(fn); }
+    onChange: (fn) => { listeners.add(fn); return () => listeners.delete(fn); },
+    checkServer: () => pingServer(),
 };
 
-window.addEventListener('online', () => setState('online'));
+window.addEventListener('online', () => pingServer());
 window.addEventListener('offline', () => setState('offline'));
+
+// Perform an initial ping so UI reflects local server reachability
+pingServer();

--- a/public/js/dataClient.js
+++ b/public/js/dataClient.js
@@ -14,7 +14,6 @@ async function fetchWithTimeout(url, options = {}, timeout = 5000){
     try {
         const resp = await fetch(withBase(url), { ...options, signal: controller.signal });
         clearTimeout(id);
-        if (!resp.ok) throw new Error('HTTP ' + resp.status);
         return resp;
     } catch (err){
         clearTimeout(id);
@@ -25,14 +24,15 @@ async function fetchWithTimeout(url, options = {}, timeout = 5000){
 async function safeGetJson(path){
     try {
         const res = await fetchWithTimeout(path);
-        connectivity.setOnline();
         if (!res.ok){
+            connectivity.setOnline();
             return { error: true, status: res.status };
         }
+        connectivity.setOnline();
         return await res.json();
     } catch (err){
-        connectivity.setOffline();
-        return { offline: true };
+        await connectivity.checkServer();
+        return { offline: connectivity.isOffline() };
     }
 }
 

--- a/public/js/dataClient.js
+++ b/public/js/dataClient.js
@@ -135,7 +135,8 @@ export async function getPlantImage(plant){
     if (blob){
         return URL.createObjectURL(blob);
     }
-    if (!connectivity.isOffline()){
+    const reachable = connectivity.isOffline() ? (await connectivity.checkServer()) === 'online' : true;
+    if (reachable){
         try {
             const res = await fetch(withBase('/' + (plant.image || '').replace(/^\/+/, '')));
             if (res.ok){

--- a/public/js/dataClient.js
+++ b/public/js/dataClient.js
@@ -1,0 +1,148 @@
+import { cacheImage, cacheLocations, cachePlants, cacheSyncMeta, cacheTimes, readImage, readLocations, readPlants, readSyncMeta, readTimes } from './storage.js';
+import { connectivity } from './connectivity.js';
+
+function withBase(path){
+    if (window.API_BASE){
+        return window.API_BASE.replace(/\/$/, '') + path;
+    }
+    return path;
+}
+
+async function fetchWithTimeout(url, options = {}, timeout = 3000){
+    const controller = new AbortController();
+    const id = setTimeout(() => controller.abort(), timeout);
+    try {
+        const resp = await fetch(withBase(url), { ...options, signal: controller.signal });
+        clearTimeout(id);
+        if (!resp.ok) throw new Error('HTTP ' + resp.status);
+        return resp;
+    } catch (err){
+        clearTimeout(id);
+        throw err;
+    }
+}
+
+async function safeGetJson(path){
+    try {
+        const res = await fetchWithTimeout(path);
+        connectivity.setOnline();
+        return await res.json();
+    } catch (err){
+        connectivity.setOffline();
+        return { offline: true };
+    }
+}
+
+async function cacheImages(changed){
+    for (const item of changed){
+        try {
+            const res = await fetch(withBase('/' + (item.image || '').replace(/^\/+/, '')));
+            if (!res.ok) continue;
+            const blob = await res.blob();
+            await cacheImage(`${item.plantId}:${item.updatedAt}`, blob);
+        } catch (err){
+            // ignore fetch errors for images
+        }
+    }
+}
+
+async function applySync(payload){
+    const meta = await readSyncMeta();
+    const currentPlants = await readPlants();
+    const plantMap = new Map(currentPlants.map(p => [p.id || p.uuid || p.name, p]));
+
+    if (payload.plants){
+        (payload.plants.upsert || []).forEach(p => {
+            const id = p.id || p.uuid || p.name;
+            plantMap.set(id, { ...p, id });
+        });
+        (payload.plants.deleted || []).forEach(d => {
+            const id = d.id || d.name;
+            plantMap.delete(id);
+        });
+    }
+
+    const merged = Array.from(plantMap.values());
+    await cachePlants(merged);
+
+    if (payload.locations){
+        if (payload.locations.upsert && payload.locations.upsert.length){
+            await cacheLocations(payload.locations.upsert);
+        }
+        if (payload.locations.deleted && payload.locations.deleted.length){
+            const locs = await readLocations();
+            const filtered = locs.filter(l => !payload.locations.deleted.includes(l));
+            await cacheLocations(filtered);
+        }
+    }
+
+    if (payload.lastClickedTimes){
+        await cacheTimes(payload.lastClickedTimes);
+    }
+
+    if (payload.images && payload.images.changed){
+        cacheImages(payload.images.changed);
+    }
+
+    await cacheSyncMeta({ lastServerRev: payload.serverRev || meta.lastServerRev, lastSyncAt: Date.now() });
+}
+
+export async function syncIfOnline(){
+    const meta = await readSyncMeta();
+    const since = meta.lastServerRev || 0;
+    const payload = await safeGetJson(`/sync${since ? `?since=${since}` : ''}`);
+    if (payload.offline) return false;
+    await applySync(payload);
+    return true;
+}
+
+export async function getPlants(){
+    const cached = await readPlants();
+    const remote = await safeGetJson('/plants');
+    if (!remote.offline){
+        await cachePlants(remote);
+        return remote;
+    }
+    return cached;
+}
+
+export async function getLocations(){
+    const cached = await readLocations();
+    const remote = await safeGetJson('/locations');
+    if (!remote.offline){
+        await cacheLocations(remote);
+        return remote;
+    }
+    return cached;
+}
+
+export async function getLastClickedTimes(){
+    const cached = await readTimes();
+    const remote = await safeGetJson('/lastClickedTimes');
+    if (!remote.offline){
+        await cacheTimes(remote);
+        return remote;
+    }
+    return cached;
+}
+
+export async function getPlantImage(plant){
+    const key = `${plant.id || plant.uuid || plant.name}:${plant.updatedAt || ''}`;
+    const blob = await readImage(key);
+    if (blob){
+        return URL.createObjectURL(blob);
+    }
+    if (!connectivity.isOffline()){
+        try {
+            const res = await fetch(withBase('/' + (plant.image || '').replace(/^\/+/, '')));
+            if (res.ok){
+                const b = await res.blob();
+                await cacheImage(key, b);
+                return URL.createObjectURL(b);
+            }
+        } catch (err){
+            // ignore
+        }
+    }
+    return plant.image;
+}

--- a/public/js/storage.js
+++ b/public/js/storage.js
@@ -27,11 +27,20 @@ lf.config({ name: 'PlantCareTracker', storeName: 'pct' });
 export const plantsStore = lf.createInstance({ storeName: 'plants' });
 export const locsStore   = lf.createInstance({ storeName: 'locations' });
 export const outbox      = lf.createInstance({ storeName: 'outbox' });
+export const timesStore  = lf.createInstance({ storeName: 'times' });
+export const syncStore   = lf.createInstance({ storeName: 'sync' });
+export const imagesStore = lf.createInstance({ storeName: 'images' });
 
 export async function cachePlants(arr){ await plantsStore.setItem('all', arr); }
 export async function readPlants(){ return (await plantsStore.getItem('all')) ?? []; }
 export async function cacheLocations(arr){ await locsStore.setItem('all', arr); }
 export async function readLocations(){ return (await locsStore.getItem('all')) ?? []; }
+export async function cacheTimes(obj){ await timesStore.setItem('all', obj); }
+export async function readTimes(){ return (await timesStore.getItem('all')) ?? {}; }
+export async function cacheSyncMeta(meta){ await syncStore.setItem('meta', meta); }
+export async function readSyncMeta(){ return (await syncStore.getItem('meta')) ?? { lastServerRev: 0, lastSyncAt: 0 }; }
+export async function cacheImage(key, blob){ await imagesStore.setItem(key, blob); }
+export async function readImage(key){ return imagesStore.getItem(key); }
 export async function queue(op){                // op = {method, url, body, ts}
   const q = (await outbox.getItem('ops')) ?? [];
   q.push(op); await outbox.setItem('ops', q);

--- a/public/plant.html
+++ b/public/plant.html
@@ -9,6 +9,9 @@
     <link href="styles.css" rel="stylesheet">
 </head>
 <body class="container">
+    <div id="offline-indicator" class="alert alert-warning text-center" role="alert" style="display:none;">
+        Offline (lecture seule)
+    </div>
     <a href="index.html" class="btn btn-link back-link">&larr; Back to Dashboard</a>
     <h1 id="plant-name" class="mb-4"></h1>
     <input type="text" id="plant-name-input" class="form-control mb-4 d-none" />

--- a/server.js
+++ b/server.js
@@ -150,6 +150,8 @@ if (!serverMeta.locationsRev) serverMeta.locationsRev = serverMeta.serverRev;
 if (!serverMeta.lastClickedTimesRev) serverMeta.lastClickedTimesRev = serverMeta.serverRev;
 writeMeta();
 
+app.get('/ping', (req, res) => res.sendStatus(204));
+
 app.use(express.static('public'));
 app.use((req, res, next) => {
     res.header('Access-Control-Allow-Origin', '*');


### PR DESCRIPTION
## Summary
- add server-side revision tracking with /sync endpoint and deletion tombstones
- cache plants, locations, times, and images via IndexedDB/localforage with connectivity tracking
- show offline read-only indicators and disable mutating actions when offline

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694c24c89090832abd1a855bd0d9ffe4)