### PR TITLE
Create consolidated settings page for locations and backend connection

### DIFF
--- a/public/create.html
+++ b/public/create.html
@@ -72,7 +72,6 @@
     <script src="https://cdn.jsdelivr.net/npm/localforage@1.10.0/dist/localforage.min.js"></script>
     <script src="config.js"></script>
     <script src="offline.js"></script>
-    <script src="js/settings.js"></script>
     <script src="leafAnimations.js"></script>
     <script type="module" src="create.js"></script>
 </body>

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
 <body class="container">
     <div class="d-flex justify-content-end mb-2 align-items-center top-controls">
         <select id="location-select" class="form-select w-auto"></select>
-        <a href="locations.html" class="btn btn-outline-secondary ms-2">Manage</a>
+        <a href="locations.html" class="btn btn-outline-secondary ms-2">Settings</a>
     </div>
     <div class="table-responsive">
     <table id="plantsTable" class="table table-bordered">
@@ -27,7 +27,6 @@
     <script src="https://cdn.jsdelivr.net/npm/localforage@1.10.0/dist/localforage.min.js"></script>
     <script src="config.js"></script>
     <script src="offline.js"></script>
-    <script src="js/settings.js"></script>
     <script type="module" src="script.js"></script>
     <script>
     if ('serviceWorker' in navigator){

--- a/public/locations.html
+++ b/public/locations.html
@@ -1,18 +1,55 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>Manage Locations</title>
+    <title>Settings</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="styles.css" rel="stylesheet">
 </head>
 <body class="container">
-    <h1 class="h4 my-3">Manage Locations</h1>
-    <div class="mb-3 d-flex">
-        <input id="new-location" class="form-control me-2" placeholder="New location">
-        <button id="add-location" class="btn btn-primary">Add</button>
+    <h1 class="h4 my-3">Settings</h1>
+    <p class="text-muted">Manage your plant tracker locations and how the app connects to the backend.</p>
+
+    <div class="card mb-4">
+        <div class="card-body">
+            <div class="d-flex justify-content-between align-items-center mb-2">
+                <div>
+                    <h2 class="h5 mb-1">Locations</h2>
+                    <p class="text-muted small mb-0">Add or remove places where your plants live.</p>
+                </div>
+            </div>
+            <div class="mb-3 d-flex flex-column flex-md-row">
+                <input id="new-location" class="form-control me-md-2 mb-2 mb-md-0" placeholder="New location">
+                <button id="add-location" class="btn btn-primary">Add location</button>
+            </div>
+            <ul id="locations-list" class="list-group"></ul>
+        </div>
     </div>
-    <ul id="locations-list" class="list-group mb-3"></ul>
+
+    <div class="card mb-4">
+        <div class="card-body">
+            <h2 class="h5 mb-1">Backend connection</h2>
+            <p class="text-muted small">Update the IP/host and port used for API requests on your network.</p>
+            <form id="api-settings-form" class="row g-3 align-items-end">
+                <div class="col-md-8">
+                    <label class="form-label small" for="api-host">IP / Host</label>
+                    <input id="api-host" class="form-control" placeholder="192.168.1.31">
+                </div>
+                <div class="col-md-4 col-lg-3">
+                    <label class="form-label small" for="api-port">Port</label>
+                    <input id="api-port" class="form-control" placeholder="2000">
+                </div>
+                <div class="col-12 d-flex justify-content-end gap-2">
+                    <button id="api-reset" type="button" class="btn btn-link">Use default</button>
+                    <button id="api-save" class="btn btn-primary" type="submit">Save</button>
+                </div>
+                <div class="col-12">
+                    <div id="api-settings-status" class="small text-muted"></div>
+                </div>
+            </form>
+        </div>
+    </div>
+
     <a href="index.html" class="btn btn-secondary">Back</a>
     <script src="https://cdn.jsdelivr.net/npm/localforage@1.10.0/dist/localforage.min.js"></script>
     <script src="config.js"></script>

--- a/public/plant.html
+++ b/public/plant.html
@@ -84,7 +84,6 @@
     <script src="https://cdn.jsdelivr.net/npm/localforage@1.10.0/dist/localforage.min.js"></script>
     <script src="config.js"></script>
     <script src="offline.js"></script>
-    <script src="js/settings.js"></script>
     <script src="leafAnimations.js"></script>
     <script type="module" src="plant.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- rename the Manage link to Settings across the app
- rework the settings page with sections for location management and backend connection details
- simplify the settings script to drive the inline connection form and remove the old toggle button

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694cf66ca184832abe4e7e4b3c8143ee)